### PR TITLE
DW-3020 fix double entry that made tests fail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,6 @@ services:
       --column.family=topic
       --topic.name=db.penalties-and-deductions.sanction
       --data.ready.flag.location=/opt/hbase-to-mongo-export/data/ready
-      --data.key.service.url=https://dks-standalone-https:8443
       --encrypt.output=true
       --compress.output=true
       --output.batch.size.max.bytes=2048


### PR DESCRIPTION
DW-3020 fix double entry that made tests fail - keep only env var use of `--data.key.service.url=${DATA_KEY_SERVICE_URL_SSL}` in same container