### PR TITLE
Adding HTME correlationId to calls to DKS

### DIFF
--- a/src/main/kotlin/app/utils/UUIDUtils.kt
+++ b/src/main/kotlin/app/utils/UUIDUtils.kt
@@ -1,0 +1,12 @@
+package app.utils
+
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class UUIDGenerator {
+
+    fun randomUUID(): String{
+        return UUID.randomUUID().toString()
+    }
+}

--- a/src/main/kotlin/app/utils/logging/LoggerUtils.kt
+++ b/src/main/kotlin/app/utils/logging/LoggerUtils.kt
@@ -35,7 +35,7 @@ private var environment = System.getProperty("environment", UNSET_TEXT)
 private var application = System.getProperty("application", UNSET_TEXT)
 private var app_version = System.getProperty("app_version", UNSET_TEXT)
 private var component = System.getProperty("component", UNSET_TEXT)
-private var correlation_id = System.getProperty("correlation_id", UNSET_TEXT)
+var correlation_id = System.getProperty("correlation_id", UNSET_TEXT)
 private var staticData = makeLoggerStaticDataTuples()
 
 class LogConfiguration {

--- a/src/main/kotlin/app/utils/logging/LoggerUtils.kt
+++ b/src/main/kotlin/app/utils/logging/LoggerUtils.kt
@@ -35,7 +35,7 @@ private var environment = System.getProperty("environment", UNSET_TEXT)
 private var application = System.getProperty("application", UNSET_TEXT)
 private var app_version = System.getProperty("app_version", UNSET_TEXT)
 private var component = System.getProperty("component", UNSET_TEXT)
-var correlation_id = System.getProperty("correlation_id", UNSET_TEXT)
+private var correlation_id = System.getProperty("correlation_id", UNSET_TEXT)
 private var staticData = makeLoggerStaticDataTuples()
 
 class LogConfiguration {

--- a/src/test/kotlin/app/configuration/TestContextConfiguration.kt
+++ b/src/test/kotlin/app/configuration/TestContextConfiguration.kt
@@ -1,6 +1,7 @@
 package app.configuration
 
 import app.services.KeyService
+import app.utils.UUIDGenerator
 import com.amazonaws.services.s3.AmazonS3
 import org.apache.hadoop.hbase.client.Connection
 import org.apache.http.client.HttpClient
@@ -12,6 +13,10 @@ import java.security.SecureRandom
 
 @Configuration
 class TestContextConfiguration {
+
+    @Bean
+    @Profile("unitTest")
+    fun uuidGenerator() = Mockito.mock(UUIDGenerator::class.java)!!
 
     @Bean
     @Profile("unitTest")


### PR DESCRIPTION
Adding HTME correlationId to calls to DKS. Using the same ID every time - whatever one came in from the Wrapper Script, so the sqs message id by default, to tie it all together.
Added and tested a dks_correlation_id UUID per call to dks, logged separately to the main correlation_id (which is the sqs message id)