### PR TITLE
Remove slashes from export prefix.

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -55,4 +55,12 @@ ignore:
     - '*':
         reason: removed, ticket raised for project remediation (DW-3136)
         expires: 2020-03-20T00:00:00.000Z
+  SNYK-JAVA-COMFASTERXMLJACKSONCORE-559094:
+    - '*':
+        reason: removed, ticket raised for project remediation (DW-3136)
+        expires: 2020-03-20T00:00:00.000Z
+  SNYK-JAVA-COMFASTERXMLJACKSONCORE-559106:
+    - '*':
+        reason: removed, ticket raised for project remediation (DW-3136)
+        expires: 2020-03-20T00:00:00.000Z
 patch: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 version: '3'
 
 services:
+
   hbase:
-    image: harisekhon/hbase:1.4
+    image: harisekhon/hbase
     ports:
       - 9090:9090
       - 9095:9095

--- a/src/main/kotlin/app/batch/S3StreamingWriter.kt
+++ b/src/main/kotlin/app/batch/S3StreamingWriter.kt
@@ -77,7 +77,6 @@ class S3StreamingWriter(private val cipherService: CipherService,
         }
     }
 
-
     fun writeOutput(openNext: Boolean = true) {
         if (batchSizeBytes > 0) {
             currentOutputStream!!.close()

--- a/src/main/kotlin/app/batch/S3StreamingWriter.kt
+++ b/src/main/kotlin/app/batch/S3StreamingWriter.kt
@@ -77,6 +77,7 @@ class S3StreamingWriter(private val cipherService: CipherService,
         }
     }
 
+
     fun writeOutput(openNext: Boolean = true) {
         if (batchSizeBytes > 0) {
             currentOutputStream!!.close()
@@ -85,7 +86,8 @@ class S3StreamingWriter(private val cipherService: CipherService,
             val inputStream = ByteArrayInputStream(data)
             val bufferedInputStream = BufferedInputStream(inputStream)
             val filePrefix = filePrefix()
-            val objectKey: String = "$exportPrefix/$filePrefix-%06d.txt.${compressionInstanceProvider.compressionExtension()}.enc".format(currentBatch)
+            val slashRemovedPrefix = exportPrefix.replace(Regex("""/+$"""), "")
+            val objectKey: String = "${slashRemovedPrefix}/$filePrefix-%06d.txt.${compressionInstanceProvider.compressionExtension()}.enc".format(currentBatch)
             val metadata = ObjectMetadata().apply {
                 contentType = "binary/octetstream"
                 addUserMetadata("x-amz-meta-title", objectKey)

--- a/src/main/kotlin/app/batch/Validator.kt
+++ b/src/main/kotlin/app/batch/Validator.kt
@@ -8,6 +8,7 @@ import app.utils.logging.logDebug
 import app.utils.logging.logError
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import org.apache.commons.lang3.StringUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -28,7 +29,6 @@ class Validator {
         val collection = item.collection
         try {
             val jsonObject = parseDecrypted(decrypted)
-            logDebug(logger, "Successfully parsed decrypted object")
             if (null != jsonObject) {
                 val id = retrieveId(jsonObject)
                 val timeAsLong = timestampAsLong(item.lastModified)
@@ -38,8 +38,8 @@ class Validator {
                 return DecryptedRecord(jsonObject, manifestRecord)
             }
         } catch (e: Exception) {
-            logError(logger, "Error decrypting record", e, "hbase_row_id", hbaseRowId, "db_name", db, "collection_name", collection)
-            throw BadDecryptedDataException(hbaseRowId, db, collection, e.message!!)
+            logError(logger, "Error decrypting record, is blank: ${StringUtils.isBlank(decrypted)}", e, "hbase_row_id", hbaseRowId, "db_name", db, "collection_name", collection)
+            throw BadDecryptedDataException(hbaseRowId, db, collection, e.message ?: "No exception message")
         }
         return null
     }

--- a/src/main/kotlin/app/batch/Validator.kt
+++ b/src/main/kotlin/app/batch/Validator.kt
@@ -38,18 +38,14 @@ class Validator {
                 return DecryptedRecord(jsonObject, manifestRecord)
             }
         } catch (e: Exception) {
-            logError(logger, "Error decrypting record", e, "is_blank", "${StringUtils.isBlank(decrypted)}", "hbase_row_id", printableKey(hbaseRowKey), "db_name", db, "collection_name", collection)
+            logError(logger, "Error decrypting record", e, "message", e.message ?: "No message", "is_blank", "${StringUtils.isBlank(decrypted)}", "hbase_row_id", printableKey(hbaseRowKey), "db_name", db, "collection_name", collection)
             throw BadDecryptedDataException(hbaseRowId, db, collection, e.message ?: "No exception message")
         }
         return null
     }
 
     fun parseDecrypted(decrypted: String): JsonObject? {
-        try {
-            return Gson().fromJson(decrypted, JsonObject::class.java)
-        } catch (e: Exception) {
-            throw Exception(parsingException)
-        }
+        return Gson().fromJson(decrypted, JsonObject::class.java)
     }
 
     fun printableKey(key: ByteArray): String {

--- a/src/main/kotlin/app/batch/Validator.kt
+++ b/src/main/kotlin/app/batch/Validator.kt
@@ -38,7 +38,7 @@ class Validator {
                 return DecryptedRecord(jsonObject, manifestRecord)
             }
         } catch (e: Exception) {
-            logError(logger, "Error decrypting record, is blank: ${StringUtils.isBlank(decrypted)}", e, "hbase_row_id", hbaseRowId, "db_name", db, "collection_name", collection)
+            logError(logger, "Error decrypting record", e, "is_blank", "${StringUtils.isBlank(decrypted)}", "hbase_row_id", printableKey(hbaseRowKey), "db_name", db, "collection_name", collection)
             throw BadDecryptedDataException(hbaseRowId, db, collection, e.message ?: "No exception message")
         }
         return null
@@ -50,6 +50,13 @@ class Validator {
         } catch (e: Exception) {
             throw Exception(parsingException)
         }
+    }
+
+    fun printableKey(key: ByteArray): String {
+        val hash = key.slice(IntRange(0, 3))
+        val hex = hash.map { String.format("\\x%02x", it) }.joinToString("")
+        val renderable = key.slice(IntRange(4, key.size - 1)).map{ it.toChar() }.joinToString("")
+        return "${hex}${renderable}"
     }
 
     fun retrieveId(jsonObject: JsonObject): JsonObject? {

--- a/src/test/kotlin/app/batch/ValidatorTest.kt
+++ b/src/test/kotlin/app/batch/ValidatorTest.kt
@@ -23,9 +23,7 @@ class ValidatorTest {
         val decryptedDbObject = """{"_id": {"someId": "RANDOM_GUID", "declarationId": 1234}, "type": "addressDeclaration", "contractId": 1234, "addressNumber": {"type": "AddressLine", "cryptoId": 1234}, "addressLine2": null, "townCity": {"type": "AddressLine", "cryptoId": 1234}, "postcode": "SM5 2LE", "processId": 1234, "effectiveDate": {"type": "SPECIFIC_EFFECTIVE_DATE", "date": 20150320, "knownDate": 20150320}, "paymentEffectiveDate": {"type": "SPECIFIC_EFFECTIVE_DATE", "date": 20150320, "knownDate": 20150320}, "createdDateTime": {"${"$"}date": "2015-03-20T12:23:25.183Z", "_archivedDateTime": "should be replaced by _archivedDateTime"}, "_version": 2, "_archived": "should be replaced by _removed", "unicodeNull": "\u0000", "unicodeNullwithText": "some\u0000text", "lineFeedChar": "\n", "lineFeedCharWithText": "some\ntext", "carriageReturn": "\r", "carriageReturnWithText": "some\rtext", "carriageReturnLineFeed": "\r\n", "carriageReturnLineFeedWithText": "some\r\ntext", "_lastModifiedDateTime": "2018-12-14T15:01:02.000+0000"}"""
         val lastModified = "2019-07-04T07:27:35.104+0000"
         val encryptionBlock: EncryptionBlock =
-            EncryptionBlock("keyEncryptionKeyId",
-                "initialisationVector",
-                "encryptedEncryptionKey")
+            EncryptionBlock("keyEncryptionKeyId","initialisationVector","encryptedEncryptionKey")
         val sourceRecord = SourceRecord(generateFourByteChecksum("00001"),
                 10, encryptionBlock, "dbObject", "db", "collection", lastModified)
         val decrypted = validator.skipBadDecryptedRecords(sourceRecord, decryptedDbObject)

--- a/src/test/kotlin/app/batch/ValidatorTest.kt
+++ b/src/test/kotlin/app/batch/ValidatorTest.kt
@@ -46,7 +46,7 @@ class ValidatorTest {
         val exception = shouldThrow<BadDecryptedDataException> {
             validator.skipBadDecryptedRecords(sourceRecord, decryptedDbObject)
         }
-        exception.message shouldBe "Exception in processing the decrypted record id '00003' in db 'db' in collection 'collection' with the reason 'Exception occurred while parsing decrypted db object'"
+        exception.message shouldBe "Exception in processing the decrypted record id '00003' in db 'db' in collection 'collection' with the reason 'java.io.EOFException: End of input at line 1 column 32 path \$.testTwo'"
     }
 
     @Test


### PR DESCRIPTION
And prevent NPE when reporting bad decrypted record.