### PR TITLE
Use raw ByteArrayInputStream, not a wrapped one inside a BufferedInpu…

### DIFF
--- a/src/main/kotlin/app/batch/S3StreamingWriter.kt
+++ b/src/main/kotlin/app/batch/S3StreamingWriter.kt
@@ -81,7 +81,6 @@ class S3StreamingWriter(private val cipherService: CipherService,
             val data = currentOutputStream!!.data()
 
             val inputStream = ByteArrayInputStream(data)
-            val bufferedInputStream = BufferedInputStream(inputStream)
             val filePrefix = filePrefix()
             val slashRemovedPrefix = exportPrefix.replace(Regex("""/+$"""), "")
             val objectKey: String = "${slashRemovedPrefix}/$filePrefix-%06d.txt.${compressionInstanceProvider.compressionExtension()}.enc".format(currentBatch)
@@ -100,7 +99,7 @@ class S3StreamingWriter(private val cipherService: CipherService,
                 "total_snapshot_files_already_written", "$totalBatches", "total_bytes_already_written", "$totalBytes",
                 "total_records_already_written", "$totalRecords")
 
-            bufferedInputStream.use {
+            inputStream.use {
                 val request = PutObjectRequest(exportBucket, objectKey, it, metadata)
                 s3.putObject(request)
             }

--- a/src/main/kotlin/app/batch/StreamingManifestWriter.kt
+++ b/src/main/kotlin/app/batch/StreamingManifestWriter.kt
@@ -3,7 +3,6 @@ package app.batch
 import app.utils.logging.logError
 import app.utils.logging.logInfo
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.ObjectMetadata
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -16,7 +15,6 @@ class StreamingManifestWriter {
         try {
             val manifestSize = manifestFile.length()
             val manifestFileName = manifestFile.name
-            val manifestFileMetadata = manifestMetadata(manifestFileName, manifestSize)
             val prefix = "$manifestPrefix/$manifestFileName"
 
             logInfo(logger, "Writing manifest manifestFile to s3",

--- a/src/main/kotlin/app/batch/StreamingManifestWriter.kt
+++ b/src/main/kotlin/app/batch/StreamingManifestWriter.kt
@@ -4,13 +4,10 @@ import app.utils.logging.logError
 import app.utils.logging.logInfo
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ObjectMetadata
-import com.amazonaws.services.s3.model.PutObjectRequest
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.io.BufferedInputStream
 import java.io.File
-import java.io.FileInputStream
 
 @Component
 class StreamingManifestWriter {
@@ -28,11 +25,7 @@ class StreamingManifestWriter {
                 "total_manifest_files_already_written", "$totalManifestFiles",
                 "total_manifest_records_already_written", "$totalManifestRecords")
 
-            BufferedInputStream(FileInputStream(manifestFile)).use { inputStream ->
-                val request = PutObjectRequest(manifestBucket, prefix, inputStream, manifestFileMetadata)
-                s3.putObject(request)
-            }
-
+            s3.putObject(manifestBucket, prefix, manifestFile)
             totalManifestFiles++
             totalManifestRecords += manifestSize
             return true
@@ -41,13 +34,6 @@ class StreamingManifestWriter {
             return false
         }
     }
-
-    fun manifestMetadata(fileName: String, size: Long) =
-            ObjectMetadata().apply {
-                contentType = "text/plain"
-                addUserMetadata("x-amz-meta-title", fileName)
-                contentLength = size
-            }
 
     companion object {
         val logger: Logger = LoggerFactory.getLogger(StreamingManifestWriter::class.toString())

--- a/src/main/kotlin/app/batch/StreamingManifestWriter.kt
+++ b/src/main/kotlin/app/batch/StreamingManifestWriter.kt
@@ -17,13 +17,23 @@ class StreamingManifestWriter {
             val manifestFileName = manifestFile.name
             val prefix = "$manifestPrefix/$manifestFileName"
 
-            logInfo(logger, "Writing manifest manifestFile to s3",
+            logInfo(logger, "Writing manifest file to s3",
                 "s3_location", "s3://$manifestBucket/$prefix",
                 "manifest_size", "$manifestSize",
                 "total_manifest_files_already_written", "$totalManifestFiles",
                 "total_manifest_records_already_written", "$totalManifestRecords")
 
             s3.putObject(manifestBucket, prefix, manifestFile)
+
+            logInfo(logger, "Written manifest file to s3",
+                    "s3_location", "s3://$manifestBucket/$prefix",
+                    "manifest_file", "$manifestFile")
+
+            val deleted = manifestFile.delete()
+
+            logInfo(logger, "Deleted manifest file",
+                    "manifest_file", "$manifestFile", "success", "$deleted")
+
             totalManifestFiles++
             totalManifestRecords += manifestSize
             return true


### PR DESCRIPTION
…tStream.

A ByteArrayInputStream is automatically 'marked' at position zero which allows
the amazon library to reset and retry the upload in case of failure.