### PR TITLE
Implement retries on s3 puts.

### DIFF
--- a/src/main/kotlin/app/batch/S3StreamingWriter.kt
+++ b/src/main/kotlin/app/batch/S3StreamingWriter.kt
@@ -3,13 +3,8 @@ package app.batch
 import app.configuration.CompressionInstanceProvider
 import app.domain.EncryptingOutputStream
 import app.domain.Record
-import app.services.CipherService
-import app.services.ExportStatusService
-import app.services.KeyService
-import app.services.SnapshotSenderMessagingService
+import app.services.*
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.ObjectMetadata
-import com.amazonaws.services.s3.model.PutObjectRequest
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.springframework.batch.core.ExitStatus
 import org.springframework.batch.core.StepExecution
@@ -40,8 +35,9 @@ class S3StreamingWriter(private val cipherService: CipherService,
                         private val streamingManifestWriter: StreamingManifestWriter,
                         private val compressionInstanceProvider: CompressionInstanceProvider,
                         private val exportStatusService: ExportStatusService,
-                        private val snapshotSenderMessagingService: SnapshotSenderMessagingService):
-        ItemWriter<Record> {
+                        private val snapshotSenderMessagingService: SnapshotSenderMessagingService,
+                        private val s3ObjectService: S3ObjectService):
+    ItemWriter<Record> {
 
     private var absoluteStart: Int = Int.MIN_VALUE
     private var absoluteStop: Int = Int.MAX_VALUE
@@ -63,69 +59,64 @@ class S3StreamingWriter(private val cipherService: CipherService,
     }
 
     override fun write(items: MutableList<out Record>) {
-        items.forEach {
-            val item = "${it.dbObjectAsString}\n"
+        items.forEach { record ->
+
+            val item = "${record.dbObjectAsString}\n"
+
             if (batchSizeBytes + item.length > maxBatchOutputSizeBytes || batchSizeBytes == 0) {
                 writeOutput()
             }
-            currentOutputStream!!.write(item.toByteArray())
-            batchSizeBytes += item.length
-            recordsInBatch++
-            currentOutputStream!!.writeManifestRecord(it.manifestRecord)
+
+            currentOutputStream?.let { output ->
+                output.write(item.toByteArray())
+                batchSizeBytes += item.length
+                recordsInBatch++
+                output.writeManifestRecord(record.manifestRecord)
+            }
         }
     }
 
     fun writeOutput(openNext: Boolean = true) {
         if (batchSizeBytes > 0) {
-            val closed = currentOutputStream!!.close()
-
-
-            val data = currentOutputStream!!.data()
-
-            val inputStream = ByteArrayInputStream(data)
             val filePrefix = filePrefix()
             val slashRemovedPrefix = exportPrefix.replace(Regex("""/+$"""), "")
-            val objectKey: String = "${slashRemovedPrefix}/$filePrefix-%06d.txt.${compressionInstanceProvider.compressionExtension()}.enc".format(currentBatch)
+            val objectKey =
+                "${slashRemovedPrefix}/$filePrefix-%06d.txt.${compressionInstanceProvider.compressionExtension()}.enc"
+                    .format(currentBatch)
 
-            if (!closed) {
-                logger.error("Failed to close output streams cleanly", "object_key" to objectKey)
-            }
+            currentOutputStream?.let { encryptingOutputStream ->
+                try {
+                    val closed = encryptingOutputStream.close()
+                    val data = encryptingOutputStream.data()
 
-            val metadata = ObjectMetadata().apply {
-                contentType = "binary/octetstream"
-                addUserMetadata("x-amz-meta-title", objectKey)
-                addUserMetadata("iv", currentOutputStream!!.initialisationVector)
-                addUserMetadata("cipherText", currentOutputStream!!.dataKeyResult.ciphertextDataKey)
-                addUserMetadata("dataKeyEncryptionKeyId", currentOutputStream!!.dataKeyResult.dataKeyEncryptionKeyId)
-                contentLength = data.size.toLong()
-            }
+                    if (!closed) {
+                        logger.error("Failed to close output streams cleanly", "object_key" to objectKey)
+                    }
 
-            logger.info("Putting batch object into bucket",
-                "s3_location" to objectKey, "records_in_batch" to "$recordsInBatch", "batch_size_bytes" to "$batchSizeBytes",
-                "data_size_bytes" to "${data.size}", "export_bucket" to exportBucket, "max_batch_output_size_bytes" to "$maxBatchOutputSizeBytes",
-                "total_snapshot_files_already_written" to "$totalBatches", "total_bytes_already_written" to "$totalBytes",
-                "total_records_already_written" to "$totalRecords")
+                    s3ObjectService.putObject(objectKey, encryptingOutputStream)
 
-            inputStream.use {
-                val request = PutObjectRequest(exportBucket, objectKey, it, metadata)
-                s3.putObject(request)
-            }
+                    logger.info("Put batch object into bucket",
+                        "s3_location" to objectKey,
+                        "records_in_batch" to "$recordsInBatch",
+                        "batch_size_bytes" to "$batchSizeBytes",
+                        "data_size_bytes" to "${data.size}",
+                        "export_bucket" to exportBucket,
+                        "max_batch_output_size_bytes" to "$maxBatchOutputSizeBytes",
+                        "total_snapshot_files_already_written" to "$totalBatches",
+                        "total_bytes_already_written" to "$totalBytes",
+                        "total_records_already_written" to "$totalRecords")
 
-            logger.info("Put batch object into bucket")
-
-            exportStatusService.incrementExportedCount(objectKey)
-            snapshotSenderMessagingService.notifySnapshotSender(objectKey)
-            
-            totalBatches++
-            totalBytes += batchSizeBytes
-            totalRecords += recordsInBatch
-
-            try {
-                streamingManifestWriter.sendManifest(s3, currentOutputStream!!.manifestFile, manifestBucket, manifestPrefix)
-                totalManifestFiles++
-                totalManifestRecords += currentOutputStream!!.manifestFile.length()
-            } catch (e: Exception) {
-                logger.error("Failed to write manifest", e, "manifest_file" to "${currentOutputStream!!.manifestFile}")
+                    exportStatusService.incrementExportedCount(objectKey)
+                    snapshotSenderMessagingService.notifySnapshotSender(objectKey)
+                    totalBatches++
+                    totalBytes += batchSizeBytes
+                    totalRecords += recordsInBatch
+                    streamingManifestWriter.sendManifest(s3, encryptingOutputStream.manifestFile, manifestBucket, manifestPrefix)
+                    totalManifestFiles++
+                    totalManifestRecords += encryptingOutputStream.manifestFile.length()
+                } catch (e: Exception) {
+                    logger.error("Failed to write data", e,"object_key" to objectKey, "manifest_file" to "${encryptingOutputStream.manifestFile}")
+                }
             }
         }
 
@@ -156,7 +147,8 @@ class S3StreamingWriter(private val cipherService: CipherService,
             keyResponse,
             Base64.getEncoder().encodeToString(initialisationVector),
             manifestFile,
-            manifestWriter)
+            manifestWriter
+        )
     }
 
     private fun filePrefix() = "$topicName-%03d-%03d".format(absoluteStart, absoluteStop)

--- a/src/main/kotlin/app/services/S3ObjectService.kt
+++ b/src/main/kotlin/app/services/S3ObjectService.kt
@@ -1,0 +1,7 @@
+package app.services
+
+import app.domain.EncryptingOutputStream
+
+interface S3ObjectService {
+    fun putObject(objectKey: String, encryptingOutputStream: EncryptingOutputStream)
+}

--- a/src/main/kotlin/app/services/impl/S3ObjectServiceImpl.kt
+++ b/src/main/kotlin/app/services/impl/S3ObjectServiceImpl.kt
@@ -1,0 +1,46 @@
+package app.services.impl
+
+import app.domain.EncryptingOutputStream
+import app.services.S3ObjectService
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.PutObjectRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Service
+import uk.gov.dwp.dataworks.logging.DataworksLogger
+import java.io.ByteArrayInputStream
+
+@Service
+class S3ObjectServiceImpl(private val amazonS3: AmazonS3): S3ObjectService {
+
+    @Retryable(value = [Exception::class],
+        maxAttemptsExpression = "\${s3.retry.maxAttempts:5}",
+        backoff = Backoff(delayExpression = "\${s3.retry.delay:1000}",
+            multiplierExpression = "\${s3.retry.multiplier:2}"))
+    override fun putObject(objectKey: String, encryptingOutputStream: EncryptingOutputStream) {
+        ByteArrayInputStream(encryptingOutputStream.data()).use {
+            amazonS3.putObject(PutObjectRequest(exportBucket, objectKey, it,
+                objectMetadata(objectKey, encryptingOutputStream)))
+        }
+    }
+
+    private fun objectMetadata(objectKey: String,
+                               encryptingOutputStream: EncryptingOutputStream): ObjectMetadata =
+            ObjectMetadata().apply {
+               contentType = "binary/octetstream"
+               addUserMetadata("x-amz-meta-title", objectKey)
+               addUserMetadata("iv", encryptingOutputStream.initialisationVector)
+               addUserMetadata("cipherText", encryptingOutputStream.dataKeyResult.ciphertextDataKey)
+               addUserMetadata("dataKeyEncryptionKeyId", encryptingOutputStream.dataKeyResult.dataKeyEncryptionKeyId)
+               contentLength = encryptingOutputStream.data().size.toLong()
+           }
+
+    @Value("\${s3.bucket}")
+    private lateinit var exportBucket: String
+
+    companion object {
+        private val logger = DataworksLogger.getLogger(S3ObjectService::class)
+    }
+}

--- a/src/test/kotlin/app/batch/HBaseResultProcessorTest.kt
+++ b/src/test/kotlin/app/batch/HBaseResultProcessorTest.kt
@@ -4,6 +4,7 @@ import app.batch.processor.HBaseResultProcessor
 import app.domain.EncryptionBlock
 import app.domain.SourceRecord
 import app.exceptions.MissingFieldException
+import app.utils.TextUtils
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.sqs.AmazonSQS
 import com.nhaarman.mockitokotlin2.doReturn
@@ -23,9 +24,8 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit4.SpringRunner
-import java.nio.charset.Charset
-import app.utils.TextUtils
 import org.springframework.test.util.ReflectionTestUtils
+import java.nio.charset.Charset
 
 @RunWith(SpringRunner::class)
 @ActiveProfiles("phoneyCipherService", "phoneyDataKeyService", "unitTest", "outputToConsole")
@@ -42,6 +42,7 @@ import org.springframework.test.util.ReflectionTestUtils
     "identity.store.alias=cid",
     "hbase.zookeeper.quorum=hbase",
     "aws.region=eu-west-2",
+    "s3.bucket=bucket",
     "snapshot.sender.sqs.queue.url=http://aws:4566",
     "snapshot.sender.reprocess.files=true",
     "snapshot.sender.shutdown.flag=true",

--- a/src/test/kotlin/app/batch/S3StreamingWriterTest.kt
+++ b/src/test/kotlin/app/batch/S3StreamingWriterTest.kt
@@ -4,13 +4,9 @@ import app.configuration.CompressionInstanceProvider
 import app.domain.DataKeyResult
 import app.domain.ManifestRecord
 import app.domain.Record
-import app.services.CipherService
-import app.services.ExportStatusService
-import app.services.KeyService
-import app.services.SnapshotSenderMessagingService
+import app.services.*
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.PutObjectRequest
 import com.amazonaws.services.sqs.AmazonSQS
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
@@ -42,6 +38,7 @@ import java.security.SecureRandom
     "s3.manifest.bucket=manifests",
     "s3.manifest.prefix.folder=manifestprefix",
     "s3.prefix.folder=prefix",
+    "s3.bucket=bucket",
     "topic.name=db.database.collection",
     "snapshot.sender.sqs.queue.url=http://aws:4566",
     "snapshot.sender.reprocess.files=true",
@@ -59,6 +56,9 @@ class S3StreamingWriterTest {
 
     @MockBean
     private lateinit var keyService: KeyService
+
+    @MockBean
+    private lateinit var s3ObjectService: S3ObjectService
 
     @MockBean
     @SuppressWarnings("Unused")
@@ -153,9 +153,8 @@ class S3StreamingWriterTest {
         }
 
         s3StreamingWriter.writeOutput()
-        val putObjectRequest = argumentCaptor<PutObjectRequest>()
         Mockito.verify(s3StreamingWriter, times(5)).writeOutput()
-        Mockito.verify(s3, times(4)).putObject(putObjectRequest.capture())
+        Mockito.verify(s3ObjectService, times(4)).putObject(any(), any())
         Mockito.verify(streamingManifestWriter, times(4)).sendManifest(any(), any(), any(), any())
    }
 

--- a/src/test/kotlin/app/batch/processor/DecryptionProcessorTest.kt
+++ b/src/test/kotlin/app/batch/processor/DecryptionProcessorTest.kt
@@ -36,6 +36,7 @@ import org.springframework.test.context.junit4.SpringRunner
     "identity.store.alias=cid",
     "hbase.zookeeper.quorum=hbase",
     "aws.region=eu-west-2",
+    "s3.bucket=bucket",
     "snapshot.sender.sqs.queue.url=http://aws:4566",
     "snapshot.sender.reprocess.files=true",
     "snapshot.sender.shutdown.flag=true",

--- a/src/test/kotlin/app/batch/processor/SanitisationProcessorTest.kt
+++ b/src/test/kotlin/app/batch/processor/SanitisationProcessorTest.kt
@@ -32,6 +32,7 @@ import org.springframework.test.context.junit4.SpringRunner
     "identity.store.alias=cid",
     "hbase.zookeeper.quorum=hbase",
     "aws.region=eu-west-2",
+    "s3.bucket=bucket",
     "s3.manifest.prefix.folder",
     "snapshot.sender.sqs.queue.url=http://aws:4566",
     "snapshot.sender.reprocess.files=true",

--- a/src/test/kotlin/app/services/impl/AESCipherServiceTest.kt
+++ b/src/test/kotlin/app/services/impl/AESCipherServiceTest.kt
@@ -34,7 +34,8 @@ import org.springframework.test.context.junit4.SpringRunner
     "snapshot.sender.shutdown.flag=true",
     "snapshot.sender.export.date=2020-06-05",
     "trigger.snapshot.sender=false",
-    "snapshot.type=full"
+    "snapshot.type=full",
+    "s3.bucket=bucket"
 ])
 class AESCipherServiceTest {
 

--- a/src/test/kotlin/app/services/impl/HttpKeyServiceTest.kt
+++ b/src/test/kotlin/app/services/impl/HttpKeyServiceTest.kt
@@ -16,7 +16,6 @@ import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.impl.client.CloseableHttpClient
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import org.junit.Before
@@ -49,7 +48,8 @@ import java.io.ByteArrayInputStream
     "trust.store.password=changeit",
     "identity.store.alias=cid",
     "hbase.zookeeper.quorum=hbase",
-    "aws.region=eu-west-2",
+    "s3.bucket=bucket",
+    "snapshot.sender.sqs.queue.url=http://aws:4566",
     "snapshot.sender.sqs.queue.url=http://aws:4566",
     "snapshot.sender.reprocess.files=true",
     "snapshot.sender.shutdown.flag=true",

--- a/src/test/kotlin/app/services/impl/S3ObjectServiceImplTest.kt
+++ b/src/test/kotlin/app/services/impl/S3ObjectServiceImplTest.kt
@@ -1,0 +1,72 @@
+package app.services.impl
+
+import app.domain.DataKeyResult
+import app.domain.EncryptingOutputStream
+import app.services.S3ObjectService
+import com.amazonaws.services.s3.AmazonS3
+import com.nhaarman.mockitokotlin2.*
+import junit.framework.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.retry.annotation.EnableRetry
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit4.SpringRunner
+import java.io.BufferedOutputStream
+import java.io.ByteArrayOutputStream
+
+@RunWith(SpringRunner::class)
+@SpringBootTest(classes = [S3ObjectServiceImpl::class])
+@EnableRetry
+@TestPropertySource(properties = [
+    "s3.retry.maxAttempts=5",
+    "s3.retry.delay=1",
+    "s3.retry.multiplier=1"
+])
+class S3ObjectServiceImplTest {
+
+    @Before
+    fun beforeEach() {
+        reset(amazonS3)
+    }
+
+    @Test
+    fun givesUpAfterMaxRetries() {
+        given(amazonS3.putObject(any())).willThrow(RuntimeException("ERROR"))
+        try {
+            s3ObjectService.putObject("key", encryptingOutputStream())
+            fail("Exception expected")
+        } catch (e: Exception) {
+            // just catch it
+        }
+        verify(amazonS3, times(5)).putObject(any())
+    }
+
+
+    @Test
+    fun retriesUntilSuccessful() {
+        given(amazonS3.putObject(any()))
+            .willThrow(RuntimeException("ERROR 1"))
+            .willThrow(RuntimeException("ERROR 2"))
+            .willThrow(RuntimeException("ERROR 3"))
+            .willReturn(mock())
+        s3ObjectService.putObject("key", encryptingOutputStream())
+        verify(amazonS3, times(4)).putObject(any())
+    }
+
+    private fun dataKeyResult(): DataKeyResult =
+        DataKeyResult("dataKeyEncryptionKeyId", "plaintextDatakey", "ciphertextDataKey")
+
+    private fun encryptingOutputStream(): EncryptingOutputStream =
+        EncryptingOutputStream(BufferedOutputStream(ByteArrayOutputStream()),
+            ByteArrayOutputStream(), dataKeyResult(), "initialisationVector", mock(), mock())
+
+    @Autowired
+    private lateinit var s3ObjectService: S3ObjectService
+
+    @MockBean
+    private lateinit var amazonS3: AmazonS3
+}


### PR DESCRIPTION
Should an attempt to put a batch of records into s3 fail the subsequent
buffer does not get re-initialised leading to errors when attempts
are made to write to it.

Retry all s3 put operations and catch and report on any attempts that
exhaust the configured max retry count.
