### PR TITLE
Prevent test runs from triggering ADG.

### DIFF
--- a/images/htme/application.properties
+++ b/images/htme/application.properties
@@ -33,6 +33,7 @@ spring.profiles.active=aesCipherService,httpDataKeyService,realHbaseDataSource,l
 sqs.retry.delay=1
 sqs.retry.maxAttempts=10
 sqs.retry.multiplier=2
+trigger.adg=true
 trigger.snapshot.sender=true
 trust.keystore=truststore.jks
 trust.store.password=changeit

--- a/resources/application.properties
+++ b/resources/application.properties
@@ -19,6 +19,7 @@ spring.profiles.active=aesCipherService,httpDataKeyService,realHbaseDataSource,l
 topic.arn.completion.full=arn:aws:sns:us-east-1:000000000000:full-completion-topic
 topic.arn.monitoring=arn:aws:sns:us-east-1:000000000000:monitoring-topic
 topic.name=db.database.collection
+trigger.adg=true
 trigger.snapshot.sender=true
 trust.keystore=truststore.jks
 trust.store.password=changeit

--- a/src/integration/kotlin/UberTestSpec.kt
+++ b/src/integration/kotlin/UberTestSpec.kt
@@ -166,8 +166,7 @@ class UberTestSpec: StringSpec() {
         "It should send the successful completion message" {
             validateQueueMessage(adgQueueUrl, """{
                     "correlation_id": "s3-export",
-                    "s3_prefix": "output",
-                    "trigger_adg": true
+                    "s3_prefix": "output"
                 }""")
         }
 

--- a/src/integration/kotlin/UberTestSpec.kt
+++ b/src/integration/kotlin/UberTestSpec.kt
@@ -166,7 +166,8 @@ class UberTestSpec: StringSpec() {
         "It should send the successful completion message" {
             validateQueueMessage(adgQueueUrl, """{
                     "correlation_id": "s3-export",
-                    "s3_prefix": "output"   
+                    "s3_prefix": "output",
+                    "trigger_adg": true
                 }""")
         }
 

--- a/src/main/kotlin/app/batch/JobCompletionNotificationListener.kt
+++ b/src/main/kotlin/app/batch/JobCompletionNotificationListener.kt
@@ -68,7 +68,9 @@ class JobCompletionNotificationListener(private val exportStatusService: ExportS
     private fun sendSnsMessages() {
         when (val completionStatus = exportStatusService.exportCompletionStatus()) {
             ExportCompletionStatus.COMPLETED_SUCCESSFULLY -> {
-                snsService.sendExportCompletedSuccessfullyMessage()
+                if (triggerAdg.toBoolean()) {
+                    snsService.sendExportCompletedSuccessfullyMessage()
+                }
                 snsService.sendMonitoringMessage(completionStatus)
             }
             ExportCompletionStatus.COMPLETED_UNSUCCESSFULLY -> {
@@ -85,6 +87,10 @@ class JobCompletionNotificationListener(private val exportStatusService: ExportS
 
     @Value("\${topic.name}")
     private lateinit var topicName: String
+
+    @Value("\${trigger.adg:false}")
+    private lateinit var triggerAdg: String
+
 
     companion object {
         val logger = DataworksLogger.getLogger(S3StreamingWriter::class)

--- a/src/main/kotlin/app/services/impl/SnsServiceImpl.kt
+++ b/src/main/kotlin/app/services/impl/SnsServiceImpl.kt
@@ -43,7 +43,8 @@ class SnsServiceImpl(private val sns: AmazonSNS): SnsService {
     private fun exportCompletedPayload() =
             """{
                 "correlation_id": "${PropertyUtility.correlationId()}",
-                "s3_prefix": "$s3prefix"   
+                "s3_prefix": "$s3prefix",
+                "trigger_adg": ${triggerAdg.toBoolean()}   
             }"""
 
     private fun monitoringPayload(exportCompletionStatus: ExportCompletionStatus) =
@@ -114,6 +115,9 @@ class SnsServiceImpl(private val sns: AmazonSNS): SnsService {
 
     @Value("\${snapshot.sender.export.date}")
     private lateinit var exportDate: String
+
+    @Value("\${trigger.adg:false}")
+    private lateinit var triggerAdg: String
 
     @Value("\${s3.prefix.folder}")
     private lateinit var s3prefix: String

--- a/src/main/kotlin/app/services/impl/SnsServiceImpl.kt
+++ b/src/main/kotlin/app/services/impl/SnsServiceImpl.kt
@@ -42,9 +42,8 @@ class SnsServiceImpl(private val sns: AmazonSNS): SnsService {
 
     private fun exportCompletedPayload() =
             """{
-                "correlation_id": "${PropertyUtility.correlationId()}",
-                "s3_prefix": "$s3prefix",
-                "trigger_adg": ${triggerAdg.toBoolean()}   
+                "correlation_id": "${correlationId()}",
+                "s3_prefix": "$s3prefix"   
             }"""
 
     private fun monitoringPayload(exportCompletionStatus: ExportCompletionStatus) =
@@ -115,9 +114,6 @@ class SnsServiceImpl(private val sns: AmazonSNS): SnsService {
 
     @Value("\${snapshot.sender.export.date}")
     private lateinit var exportDate: String
-
-    @Value("\${trigger.adg:false}")
-    private lateinit var triggerAdg: String
 
     @Value("\${s3.prefix.folder}")
     private lateinit var s3prefix: String

--- a/src/test/kotlin/app/services/impl/SnsServiceImplTest.kt
+++ b/src/test/kotlin/app/services/impl/SnsServiceImplTest.kt
@@ -36,7 +36,6 @@ class SnsServiceImplTest {
         ReflectionTestUtils.setField(snsService, "monitoringTopicArn", TOPIC_ARN)
         ReflectionTestUtils.setField(snsService, "snapshotType", "full")
         ReflectionTestUtils.setField(snsService, "s3prefix", "prefix")
-        ReflectionTestUtils.setField(snsService, "triggerAdg", "false")
         reset(amazonSNS)
     }
 
@@ -57,18 +56,9 @@ class SnsServiceImplTest {
         verifyNoMoreInteractions(amazonSNS)
     }
 
-    @Test
-    fun doesntTriggerAdg() {
-        validateMessage(false)
-    }
 
     @Test
     fun triggersAdg() {
-        validateMessage(true)
-    }
-
-    private fun validateMessage(triggerAdg: Boolean) {
-        ReflectionTestUtils.setField(snsService, "triggerAdg", "$triggerAdg")
         given(amazonSNS.publish(any())).willReturn(mock())
         snsService.sendExportCompletedSuccessfullyMessage()
         argumentCaptor<PublishRequest> {
@@ -76,12 +66,12 @@ class SnsServiceImplTest {
             assertEquals(TOPIC_ARN, firstValue.topicArn)
             assertEquals("""{
                 "correlation_id": "correlation.id",
-                "s3_prefix": "prefix",
-                "trigger_adg": $triggerAdg   
+                "s3_prefix": "prefix"   
             }""", firstValue.message)
         }
         verifyNoMoreInteractions(amazonSNS)
     }
+
 
     @Test
     fun givesUpSuccessAfterMaxTriesUntilSuccessful() {


### PR DESCRIPTION
A new flag has been added to the adg triggering message to indicate
whether adg should actually be triggered. Setting this to false
will allow end to end tests to run that don't trigger ADG.
