### PR TITLE
Send the export date to ADG, this will allow ADG to know whether it n…

### DIFF
--- a/src/integration/kotlin/UberTestSpec.kt
+++ b/src/integration/kotlin/UberTestSpec.kt
@@ -252,7 +252,8 @@ class UberTestSpec: StringSpec() {
             validateQueueMessage(adgQueueUrl, """{
                     "correlation_id": "s3-export",
                     "s3_prefix": "output",
-                    "snapshot_type": "full"
+                    "snapshot_type": "full",
+                    "export_date": "2020-07-06"
                 }""")
         }
 

--- a/src/main/kotlin/app/services/impl/SnsServiceImpl.kt
+++ b/src/main/kotlin/app/services/impl/SnsServiceImpl.kt
@@ -43,7 +43,8 @@ class SnsServiceImpl(private val sns: AmazonSNS): SnsService {
             """{
                 "correlation_id": "${correlationId()}",
                 "s3_prefix": "$s3prefix",
-                "snapshot_type": "$snapshotType"
+                "snapshot_type": "$snapshotType",
+                "export_date": "$exportDate"
             }"""
 
     private fun monitoringPayload(exportCompletionStatus: ExportCompletionStatus) =

--- a/src/test/kotlin/app/services/impl/SnsServiceImplTest.kt
+++ b/src/test/kotlin/app/services/impl/SnsServiceImplTest.kt
@@ -67,7 +67,8 @@ class SnsServiceImplTest {
             assertEquals("""{
                 "correlation_id": "correlation.id",
                 "s3_prefix": "prefix",
-                "snapshot_type": "full"
+                "snapshot_type": "full",
+                "export_date": "2020-12-12"
             }""", firstValue.message)
         }
         verifyNoMoreInteractions(amazonSNS)


### PR DESCRIPTION
Send the export date to ADG, this will allow ADG to know whether it needs to trigger PDM by knowing how late it is finishing in relation to when it first kicked off