### PR TITLE
User name

### DIFF
--- a/src/integration/kotlin/UberTestSpec.kt
+++ b/src/integration/kotlin/UberTestSpec.kt
@@ -261,7 +261,7 @@ class UberTestSpec: StringSpec() {
             validateQueueMessage(monitoringQueueUrl, """{
                     "severity": "Critical",
                     "notification_type": "Information",
-                    "slack_username": "Crown Export Poller",
+                    "slack_username": "HTME",
                     "title_text": "Full - Export finished - success",
                     "custom_elements":[
                         {

--- a/src/integration/kotlin/UberTestSpec.kt
+++ b/src/integration/kotlin/UberTestSpec.kt
@@ -252,7 +252,8 @@ class UberTestSpec: StringSpec() {
             validateQueueMessage(adgQueueUrl, """{
                     "correlation_id": "s3-export",
                     "s3_prefix": "output",
-                    "snapshot_type": "full"
+                    "snapshot_type": "full",
+                    "export_date": "2020-07-06"
                 }""")
         }
 

--- a/src/main/kotlin/app/services/impl/SnsServiceImpl.kt
+++ b/src/main/kotlin/app/services/impl/SnsServiceImpl.kt
@@ -51,7 +51,7 @@ class SnsServiceImpl(private val sns: AmazonSNS): SnsService {
             """{
                 "severity": "${severity(exportCompletionStatus)}",
                 "notification_type": "${notificationType(exportCompletionStatus)}",
-                "slack_username": "Crown Export Poller",
+                "slack_username": "HTME",
                 "title_text": "${snapshotType.capitalize()} - Export finished - ${exportCompletionStatus.description}",
                 "custom_elements": [
                     {
@@ -78,7 +78,7 @@ class SnsServiceImpl(private val sns: AmazonSNS): SnsService {
     private fun notificationType(exportCompletionStatus: ExportCompletionStatus): String =
         when (exportCompletionStatus) {
             ExportCompletionStatus.COMPLETED_UNSUCCESSFULLY -> {
-                "Error"
+                "Warning"
             }
             else -> {
                 "Information"

--- a/src/main/kotlin/app/services/impl/SnsServiceImpl.kt
+++ b/src/main/kotlin/app/services/impl/SnsServiceImpl.kt
@@ -43,7 +43,8 @@ class SnsServiceImpl(private val sns: AmazonSNS): SnsService {
             """{
                 "correlation_id": "${correlationId()}",
                 "s3_prefix": "$s3prefix",
-                "snapshot_type": "$snapshotType"
+                "snapshot_type": "$snapshotType",
+                "export_date": "$exportDate"
             }"""
 
     private fun monitoringPayload(exportCompletionStatus: ExportCompletionStatus) =

--- a/src/test/kotlin/app/services/impl/SnsServiceImplTest.kt
+++ b/src/test/kotlin/app/services/impl/SnsServiceImplTest.kt
@@ -98,7 +98,7 @@ class SnsServiceImplTest {
             assertEquals("""{
                 "severity": "Critical",
                 "notification_type": "Information",
-                "slack_username": "Crown Export Poller",
+                "slack_username": "HTME",
                 "title_text": "Full - Export finished - success",
                 "custom_elements": [
                     {
@@ -124,8 +124,8 @@ class SnsServiceImplTest {
             assertEquals(TOPIC_ARN, firstValue.topicArn)
             assertEquals("""{
                 "severity": "High",
-                "notification_type": "Error",
-                "slack_username": "Crown Export Poller",
+                "notification_type": "Warning",
+                "slack_username": "HTME",
                 "title_text": "Full - Export finished - failed",
                 "custom_elements": [
                     {

--- a/src/test/kotlin/app/services/impl/SnsServiceImplTest.kt
+++ b/src/test/kotlin/app/services/impl/SnsServiceImplTest.kt
@@ -67,7 +67,8 @@ class SnsServiceImplTest {
             assertEquals("""{
                 "correlation_id": "correlation.id",
                 "s3_prefix": "prefix",
-                "snapshot_type": "full"
+                "snapshot_type": "full",
+                "export_date": "2020-12-12"
             }""", firstValue.message)
         }
         verifyNoMoreInteractions(amazonSNS)


### PR DESCRIPTION
Change the slack notifications username to make more sende and change the failures to warnings because they flood the critical alerts whereas there is another cloudwatch alert that works and alerts there for 1 or more failed collections in a day